### PR TITLE
Create static map dashboard with React CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # EVtest
+
+Bu depo, React ve Tailwind ile haz\u0131rlanm\u0131\u015f basit bir harita uygulamas\u0131 i\u00e7in \u00f6rnek dosyalar\u0131 i\u00e7erir. `harita-dashboard` klas\u00f6r\u00fcndeki `index.html` dosyas\u0131n\u0131 taray\u0131c\u0131n\u0131zda a\u00e7arak uygulamay\u0131 kullanabilirsiniz.

--- a/harita-dashboard/README.md
+++ b/harita-dashboard/README.md
@@ -1,0 +1,13 @@
+# Harita Dashboard
+
+Basit bir React ve TailwindCSS tabanlı harita uygulaması. Dosyayı açmak için `index.html` dosyasını bir tarayıcıda açmanız yeterlidir.
+
+## Özellikler
+- GeoJSON dosyasını yükleyip Leaflet haritası üzerinde gösterme
+- Responsive (mobil uyumlu) tasarım
+- Grafikleri eklemek için `app.js` içerisinde Recharts kullanabilirsiniz
+
+## Kullanım
+1. `index.html` dosyasını destekleyen bir tarayıcıda açın.
+2. Sağ taraftaki dosya yükleme alanından `.json` uzantılı (GeoJSON formatında) bir dosya seçin.
+3. Harita üzerinde seçilen veriler görüntülenir.

--- a/harita-dashboard/app.js
+++ b/harita-dashboard/app.js
@@ -1,0 +1,43 @@
+import React, { useState } from 'https://cdn.jsdelivr.net/npm/react@18.2.0/+esm';
+import ReactDOM from 'https://cdn.jsdelivr.net/npm/react-dom@18.2.0/+esm';
+import { MapContainer, TileLayer, GeoJSON } from 'https://cdn.jsdelivr.net/npm/react-leaflet@4.2.1/+esm';
+import 'https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.js';
+
+function App() {
+  const [data, setData] = useState(null);
+
+  const handleFile = (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (evt) => {
+      try {
+        const json = JSON.parse(evt.target.result);
+        setData(json);
+      } catch (err) {
+        console.error('Ge\u00e7ersiz JSON', err);
+      }
+    };
+    reader.readAsText(file);
+  };
+
+  return (
+    <div className="flex flex-col md:flex-row h-full">
+      <div className="flex-1 h-1/2 md:h-full">
+        <MapContainer center={[0,0]} zoom={2} className="h-full">
+          <TileLayer
+            attribution="&copy; <a href='https://www.openstreetmap.org/'>OpenStreetMap</a> contributors"
+            url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+          />
+          {data && <GeoJSON data={data} />}
+        </MapContainer>
+      </div>
+      <div className="w-full md:w-1/3 overflow-auto p-4 bg-gray-100">
+        <input type="file" accept="application/json" onChange={handleFile} className="mb-4" />
+        {/* Grafik bilesenleri buraya eklenebilir */}
+      </div>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);

--- a/harita-dashboard/index.html
+++ b/harita-dashboard/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Harita Dashboard</title>
+  <link href="https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.css" rel="stylesheet" />
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="h-screen m-0">
+  <div id="root" class="h-full"></div>
+  <script type="module" src="./app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add instructions in README
- create `harita-dashboard` with a static React/Leaflet example

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68698362fe1c832799cfe9fe7309954d